### PR TITLE
Make array of struct writing to be deterministic

### DIFF
--- a/src/main/java/com/jmatio/types/MLStructureObjectBase.java
+++ b/src/main/java/com/jmatio/types/MLStructureObjectBase.java
@@ -11,12 +11,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 /**
  * Base class for MLStructure and MLObject.
@@ -42,7 +41,7 @@ public abstract class MLStructureObjectBase extends MLArray {
 		super(name, dims, type, attributes);
 
 		mlStructArray = new TreeMap<Integer, Map<String, MLArray>>();
-		keys = new LinkedHashSet<String>();
+		keys = new TreeSet<String>();
 	}
 
 	/**
@@ -81,7 +80,7 @@ public abstract class MLStructureObjectBase extends MLArray {
 
 		Map<String, MLArray> map = mlStructArray.get(index);
 		if (map == null) {
-			map = new LinkedHashMap<String, MLArray>();
+			map = new TreeMap<String, MLArray>();
 			mlStructArray.put(index, map);
 		}
 		map.put(name, value);
@@ -136,7 +135,13 @@ public abstract class MLStructureObjectBase extends MLArray {
 		ArrayList<MLArray> fields = new ArrayList<MLArray>();
 
 		for (Map<String, MLArray> struct : mlStructArray.values()) {
-			fields.addAll(struct.values());
+                    for (String s : keys) {
+                        if (struct.containsKey(s)) {
+                            fields.add(struct.get(s));
+                        } else {
+                            fields.add(new MLEmptyArray());
+                        }
+                    }
 		}
 		return fields;
 	}
@@ -146,7 +151,7 @@ public abstract class MLStructureObjectBase extends MLArray {
 	 * @return the {@link Collection} of keys for this structure
 	 */
 	public Collection<String> getFieldNames() {
-		Set<String> fieldNames = new LinkedHashSet<String>();
+		Set<String> fieldNames = new TreeSet<String>();
 
 		fieldNames.addAll(keys);
 


### PR DESCRIPTION
Currently the internals of MLStruct is using hash based set for keys and mlStructArray. However, this is prone to the sequence of field insertion. During writing, the fieldnames are taken from keys and the content are taken from mlStructArray.values(). For array of struct, it is possible that the fields are not saved in proper order, in other words, fields are not stored consistently from one item to another.

Example
s(1).m =12;
s(1).t = 'a';
s(2).a = 'bb';
s(2).t = 'tt';
s(2).m = 5;
s(1).a = 'v';

It is likely that s(1) is saved in the order of fields m, t, a and s(2) is saved in the order of a, t, m. And the keys -- as 'LinkedHashedSet' -- will be saved in entirely different order depending on the hash.

This pull request is meant to make the writing deterministic by using TreeSet and TreeMap. In addition, the order is saved following the order of keys.